### PR TITLE
fix: fix f-string SyntaxError for Python < 3.12

### DIFF
--- a/GUGUbot/gugubot/connector/qq_connector.py
+++ b/GUGUbot/gugubot/connector/qq_connector.py
@@ -443,9 +443,7 @@ class QQWebSocketConnector(BasicConnector):
         except Exception as e:
             error_msg = str(e) + "\n" + traceback.format_exc()
             self.logger.warning(
-                f"{self.log_prefix} {self.server.tr(
-                    "gugubot.connector.QQ.error_close", error=error_msg
-                )}"
+                f"{self.log_prefix} {self.server.tr('gugubot.connector.QQ.error_close', error=error_msg)}"
             )
             raise
 


### PR DESCRIPTION
更新gugubot到v2.0.30后在python3.10环境下运行遇到了报错：
```
[MCDR] [2026-03-10 06:56:38.880] [TaskExecutor/ERROR] [multi_file_plugin.py:90(_on_ready)]: Fail to load the entry point of gugubot@2.0.30
Traceback (most recent call last):
  File "/opt/minecraft/gtnh/venv/lib/python3.10/site-packages/mcdreforged/plugin/type/multi_file_plugin.py", line 88, in _on_ready
    self._load_entry_instance()
  File "/opt/minecraft/gtnh/venv/lib/python3.10/site-packages/mcdreforged/plugin/type/packed_plugin.py", line 107, in _load_entry_instance
    super()._load_entry_instance()
  File "/opt/minecraft/gtnh/venv/lib/python3.10/site-packages/mcdreforged/plugin/type/regular_plugin.py", line 81, in _load_entry_instance
    self.entry_module_instance = self._import_entrypoint_module()
  File "/opt/minecraft/gtnh/venv/lib/python3.10/site-packages/mcdreforged/plugin/type/multi_file_plugin.py", line 51, in _import_entrypoint_module
    mod = importlib.import_module(self.get_metadata().entrypoint)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "plugins/gugubot-v2.0.30.mcdr/gugubot/__init__.py", line 10, in <module>
    from gugubot.connector import (
  File "plugins/gugubot-v2.0.30.mcdr/gugubot/connector/__init__.py", line 5, in <module>
    from gugubot.connector.qq_connector import QQWebSocketConnector
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1002, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 945, in _find_spec
  File "<frozen importlib._bootstrap_external>", line 1439, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1411, in _get_spec
  File "<frozen zipimport>", line 170, in find_spec
  File "<frozen importlib._bootstrap>", line 431, in spec_from_loader
  File "<frozen importlib._bootstrap_external>", line 741, in spec_from_file_location
  File "<frozen zipimport>", line 229, in get_filename
  File "<frozen zipimport>", line 767, in _get_module_code
  File "<frozen zipimport>", line 696, in _compile_source
  File "plugins/gugubot-v2.0.30.mcdr/gugubot/connector/qq_connector.py", line 446
    f"{self.log_prefix} {self.server.tr(
    ^
SyntaxError: unterminated string literal (detected at line 446)
```
原代码在 f-string 的大括号 `{}` 内部使用了与外层相同的双引号 `"`，并且包含了换行符。由于 Python 3.12 才开始支持在 f-string 表达式中重用引号和包含换行符，这导致在 Python 3.11 及更早的版本中运行时，会直接引发 `SyntaxError`。
修复了之后就可以正常在我的本地环境运行了。