### PR TITLE
绑定逻辑调整：删除多余判断，绑定结果反应白名单添加结果。

### DIFF
--- a/GUGUbot/gugubot/logic/system/bound.py
+++ b/GUGUbot/gugubot/logic/system/bound.py
@@ -329,13 +329,13 @@ class BoundSystem(BasicSystem):
                                 .get("whitelist_add_with_bound", False)
                         and self.whitelist
                 ):
-                    return self.whitelist.add_player(
+                    return self.whitelist.add_player(  # 返回白名单添加状态
                         player_name,
                         force_offline=is_offline,
                         force_online=is_online,
                         force_bedrock=is_bedrock,
                     )
-                return False
+                return True  # 如未开启绑定时添加白名单，返回True
 
             async def _set_group_card_if_qq(
                     player_name: str,


### PR DESCRIPTION
改动：
- 删除bound中的通过whitelist_api判断默认状态下的白名单添加模式的逻辑，未指定参数时白名单模式应由whitelist_api自动管理。
- 在启用绑定时添加白名单这个功能的情况下，绑定结果受白名单添加结果影响。

此改动并不完美，只是符合我的需求：玩家使用绑定指令获取白名单，并得知是否添加成功。